### PR TITLE
Lab walkthrough docs polish + Lab1 local datagen pacing

### DIFF
--- a/LAB1-Walkthrough.md
+++ b/LAB1-Walkthrough.md
@@ -96,6 +96,10 @@ Begin generating data with the following command:
 uv run lab1_datagen --local
 ```
 
+> [!NOTE]
+>
+> Keep this command running in your terminal — it produces one order every 2 minutes. Proceed with the lab while it runs.
+
 The data generator creates three typical ecommerce data streams:
 
 - **`customers`**: 100 customer records with realistic names, emails, addresses, and state information

--- a/LAB1-Walkthrough.md
+++ b/LAB1-Walkthrough.md
@@ -22,7 +22,11 @@ In this lab, we'll use Apache Flink for Confluent Cloud's MCP tool calling featu
 
 ## Deploy the Demo
 
-Once you have these credentials ready, run the following command and choose **Lab3** (see [main README](./README.md)):
+> [!CAUTION]
+>
+> You must be logged in to the Confluent CLI before running `uv run deploy`. Run `confluent login` first if you haven't already.
+
+Once you have these credentials ready, run the following command and choose **Lab1** (see [main README](./README.md)):
 
   ```bash
   uv run deploy

--- a/LAB1-Walkthrough.md
+++ b/LAB1-Walkthrough.md
@@ -55,7 +55,7 @@ Once you have these credentials ready, run the following command and choose **La
 
 ## 1. Test the LLM models before continuing
 
-Once you've deployed Lab1, run the following queries in the [SQL Workspace](https://confluent.cloud/go/flink) to make sure your models are working as expected:
+Once you've deployed Lab1, open the [SQL Workspace](https://confluent.cloud/go/flink), select your Confluent Cloud environment, and run the following queries to make sure your models are working as expected:
 
 #### Test Query 1: Base LLM model
 
@@ -90,10 +90,10 @@ LATERAL TABLE(ML_PREDICT('llm_textgen_model', question, MAP['debug', 'true'])) a
 
 ## 2. Generate Data
 
-Open **Docker Desktop**, then begin generating data with the following command:
+Begin generating data with the following command:
 
 ```bash
-uv run lab1_datagen
+uv run lab1_datagen --local
 ```
 
 The data generator creates three typical ecommerce data streams:

--- a/LAB1-Walkthrough.md
+++ b/LAB1-Walkthrough.md
@@ -6,6 +6,25 @@ In this lab, we'll use Apache Flink for Confluent Cloud's MCP tool calling featu
 
 ## Prerequisites
 
+### Local dependencies
+
+**Installation instructions:**
+
+```bash
+brew install uv git python && brew tap hashicorp/tap && brew install hashicorp/tap/terraform && brew install --cask confluent-cli
+```
+**Windows:**
+
+```powershell
+winget install astral-sh.uv Git.Git Hashicorp.Terraform ConfluentInc.Confluent-CLI Python.Python
+```
+
+### API keys & access
+
+> [!NOTE]
+>
+> The credentials below are not required in instructor-led workshops — they will be provided for you.
+
 - **LLM Access:** AWS Bedrock API keys **OR** Azure OpenAI endpoint + API key
   - No AWS/Azure account required - just the LLM API credentials!
   - **Easy key creation:** Run `uv run api-keys create` to quickly generate ready-to-use credentials
@@ -36,7 +55,7 @@ Once you have these credentials ready, run the following command and choose **La
 
 ## 1. Test the LLM models before continuing
 
-Once you've deployed Lab1, run the following queries in the SQL Workspace to make sure your models are working as expected:
+Once you've deployed Lab1, run the following queries in the [SQL Workspace](https://confluent.cloud/go/flink) to make sure your models are working as expected:
 
 #### Test Query 1: Base LLM model
 

--- a/LAB2-Walkthrough.md
+++ b/LAB2-Walkthrough.md
@@ -16,6 +16,10 @@ In this lab, we'll create a Retrieval-Augmented Generation (RAG) pipeline using 
 
 ## Deployment
 
+> [!CAUTION]
+>
+> You must be logged in to the Confluent CLI before running `uv run deploy`. Run `confluent login` first if you haven't already.
+
 Use the setup script and select "Lab2" when prompted to automatically deploy Lab2 infrastructure:
 
 ```bash

--- a/LAB2-Walkthrough.md
+++ b/LAB2-Walkthrough.md
@@ -6,6 +6,10 @@ In this lab, we'll create a Retrieval-Augmented Generation (RAG) pipeline using 
 
 ## Prerequisites
 
+> [!NOTE]
+>
+> These prerequisites are not required in instructor-led workshops — credentials will be provided for you.
+
 - **LLM Access:** AWS Bedrock API keys **OR** Azure OpenAI endpoint + API key
   - **Easy key creation:** Run `uv run api-keys create` to quickly generate ready-to-use credentials
 - **MongoDB vector database:** Pre-configured and managed for you - no setup required.

--- a/LAB3-Walkthrough.md
+++ b/LAB3-Walkthrough.md
@@ -54,6 +54,10 @@ Be sure to pull in the latest changes:
 git pull
 ```
 
+> [!CAUTION]
+>
+> You must be logged in to the Confluent CLI before running `uv run deploy`. Run `confluent login` first if you haven't already.
+
 Once you have your credentials ready, run the deployment script and choose **Lab3**:
 
 ```bash

--- a/LAB3-Walkthrough.md
+++ b/LAB3-Walkthrough.md
@@ -16,6 +16,9 @@ All of this runs in real time on **Confluent Cloud for Apache Flink**, with no e
 ![Architecture Diagram](./assets/lab3/lab3-architecture.png)
 
 ## Prerequisites
+
+### Local dependencies
+
 **Installation instructions:**
 
 ```bash
@@ -26,7 +29,13 @@ brew install uv git python && brew tap hashicorp/tap && brew install hashicorp/t
 ```powershell
 winget install astral-sh.uv Git.Git Hashicorp.Terraform ConfluentInc.Confluent-CLI Python.Python
 ```
-Once software is installed, you'll need:
+
+### API keys & access
+
+> [!NOTE]
+>
+> The credentials below are not required in instructor-led workshops — they will be provided for you.
+
 - **LLM Access:** AWS Bedrock API keys **OR** Azure OpenAI endpoint + API key
   - **Easy key creation:** Run `uv run api-keys create` to quickly auto-generate credentials
 

--- a/LAB4-Walkthrough.md
+++ b/LAB4-Walkthrough.md
@@ -6,6 +6,8 @@ This demo showcases an intelligent, real-time fraud detection system that autono
 
 ## Prerequisites
 
+### Local dependencies
+
 **Installation instructions:**
 
 ```bash
@@ -17,7 +19,12 @@ brew install uv git python && brew tap hashicorp/tap && brew install hashicorp/t
 winget install astral-sh.uv Git.Git Hashicorp.Terraform ConfluentInc.Confluent-CLI Python.Python
 ```
 
-Once software is installed, you'll need:
+### API keys & access
+
+> [!NOTE]
+>
+> The credentials below are not required in instructor-led workshops — they will be provided for you.
+
 - **LLM API keys:** AWS Bedrock API keys **OR** Azure OpenAI endpoint + API key
   - **Easy key creation:** Run `uv run api-keys create` to quickly auto-generate credentials
 

--- a/LAB4-Walkthrough.md
+++ b/LAB4-Walkthrough.md
@@ -32,6 +32,10 @@ git clone https://github.com/confluentinc/quickstart-streaming-agents.git
 cd quickstart-streaming-agents
 ```
 
+> [!CAUTION]
+>
+> You must be logged in to the Confluent CLI before running `uv run deploy`. Run `confluent login` first if you haven't already.
+
 Once you have your credentials ready, run the deployment script and choose **Lab4**:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ uv run api-keys create
 
 3. **One command deployment:**
 
+> [!CAUTION]
+>
+> You must be logged in to the Confluent CLI before running `uv run deploy`. Run `confluent login` first if you haven't already.
+
 ```bash
 uv run deploy
 ```

--- a/scripts/publish_lab1_data.py
+++ b/scripts/publish_lab1_data.py
@@ -85,6 +85,8 @@ SCHEMAS = {
 
 TS_FIELD = {"orders": "order_ts"}
 
+ORDERS_PUBLISH_INTERVAL_SECONDS = 120
+
 
 def _parse_iso_ms(s: str) -> int:
     return int(datetime.fromisoformat(s.replace("Z", "+00:00")).timestamp() * 1000)
@@ -206,7 +208,9 @@ class Lab1DataPublisher:
             try:
                 value_dict = _coerce_row(topic, row, now_ms=now_ms)
 
-                if ts_field and ts_offset_ms and ts_field in value_dict:
+                if topic == "orders":
+                    value_dict["order_ts"] = int(time.time() * 1000)
+                elif ts_field and ts_offset_ms and ts_field in value_dict:
                     value_dict[ts_field] += ts_offset_ms
 
                 if self.dry_run:
@@ -219,7 +223,17 @@ class Lab1DataPublisher:
                 self.producer.produce(topic, value=serialized, partition=0)
                 results["success"] += 1
 
-                if idx % 100 == 0:
+                if topic == "orders":
+                    self.producer.flush()
+                    self.logger.info(
+                        f"Published order {idx}/{len(rows)}: {value_dict['order_id']}"
+                    )
+                    if idx < len(rows):
+                        self.logger.info(
+                            f"Waiting {ORDERS_PUBLISH_INTERVAL_SECONDS}s before next order..."
+                        )
+                        time.sleep(ORDERS_PUBLISH_INTERVAL_SECONDS)
+                elif idx % 100 == 0:
                     self.producer.poll(0)
 
             except Exception as e:
@@ -296,15 +310,14 @@ def main():
         if args.dry_run:
             logger.info("[DRY RUN MODE]")
 
-        orders_file = data_dir / "orders.csv"
-        ts_offset_ms = compute_orders_ts_offset(orders_file)
-        offset_minutes = ts_offset_ms / 60000
-        logger.info(f"Rebasing order_ts by {offset_minutes:+.1f} minutes")
+        logger.info(
+            f"Orders will be published one every {ORDERS_PUBLISH_INTERVAL_SECONDS}s "
+            f"with order_ts set to publish time"
+        )
 
         all_results = {}
         for topic in ("customers", "products", "orders"):
-            offset = ts_offset_ms if topic == "orders" else 0
-            results = publisher.publish_topic(topic, data_dir / f"{topic}.csv", offset)
+            results = publisher.publish_topic(topic, data_dir / f"{topic}.csv", 0)
             all_results[topic] = results
 
         print(f"\n{'=' * 55}")


### PR DESCRIPTION
## Summary
- Make `uv run lab1_datagen --local` the default in Lab1 (no Docker required) and pace local order publishing at 2 min/order with `order_ts` set to publish time.
- Clarify SQL Workspace navigation in Lab1 (open link, select environment, then run queries).
- Carry over earlier doc fixes on this branch: Confluent CLI login caution before `uv run deploy`, instructor-led workshop note, and lab prerequisite reorganization.

## Test plan
- [ ] `uv run lab1_datagen --local` runs without Docker and emits orders every 2 minutes
- [ ] Customers/products land before the first order so Flink joins succeed
- [ ] LAB1-Walkthrough.md renders correctly on GitHub (note callout, code blocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)