### PR TITLE
Remove Confluent CLI login caution since deploy auto-logs in

### DIFF
--- a/LAB1-Walkthrough.md
+++ b/LAB1-Walkthrough.md
@@ -41,10 +41,6 @@ winget install astral-sh.uv Git.Git Hashicorp.Terraform ConfluentInc.Confluent-C
 
 ## Deploy the Demo
 
-> [!CAUTION]
->
-> You must be logged in to the Confluent CLI before running `uv run deploy`. Run `confluent login` first if you haven't already.
-
 Once you have these credentials ready, run the following command and choose **Lab1** (see [main README](./README.md)):
 
   ```bash

--- a/LAB2-Walkthrough.md
+++ b/LAB2-Walkthrough.md
@@ -20,10 +20,6 @@ In this lab, we'll create a Retrieval-Augmented Generation (RAG) pipeline using 
 
 ## Deployment
 
-> [!CAUTION]
->
-> You must be logged in to the Confluent CLI before running `uv run deploy`. Run `confluent login` first if you haven't already.
-
 Use the setup script and select "Lab2" when prompted to automatically deploy Lab2 infrastructure:
 
 ```bash

--- a/LAB3-Walkthrough.md
+++ b/LAB3-Walkthrough.md
@@ -63,10 +63,6 @@ Be sure to pull in the latest changes:
 git pull
 ```
 
-> [!CAUTION]
->
-> You must be logged in to the Confluent CLI before running `uv run deploy`. Run `confluent login` first if you haven't already.
-
 Once you have your credentials ready, run the deployment script and choose **Lab3**:
 
 ```bash

--- a/LAB4-Walkthrough.md
+++ b/LAB4-Walkthrough.md
@@ -39,10 +39,6 @@ git clone https://github.com/confluentinc/quickstart-streaming-agents.git
 cd quickstart-streaming-agents
 ```
 
-> [!CAUTION]
->
-> You must be logged in to the Confluent CLI before running `uv run deploy`. Run `confluent login` first if you haven't already.
-
 Once you have your credentials ready, run the deployment script and choose **Lab4**:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -81,10 +81,6 @@ uv run api-keys create
 
 3. **One command deployment:**
 
-> [!CAUTION]
->
-> You must be logged in to the Confluent CLI before running `uv run deploy`. Run `confluent login` first if you haven't already.
-
 ```bash
 uv run deploy
 ```


### PR DESCRIPTION
## Summary
- Removes the `[!CAUTION]` callouts instructing users to run `confluent login` before `uv run deploy`, as `uv run deploy` now handles login automatically (introduced in #60).
- Affects: `README.md`, `LAB1-Walkthrough.md`, `LAB2-Walkthrough.md`, `LAB3-Walkthrough.md`, `LAB4-Walkthrough.md`.

## Test plan
- [ ] Render each updated `.md` file and confirm the caution block is gone and surrounding flow reads cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)