### PR TITLE
Add clone instructions to all lab walkthroughs

### DIFF
--- a/LAB1-Walkthrough.md
+++ b/LAB1-Walkthrough.md
@@ -41,6 +41,13 @@ winget install astral-sh.uv Git.Git Hashicorp.Terraform ConfluentInc.Confluent-C
 
 ## Deploy the Demo
 
+If you haven't already, clone the repo:
+
+```bash
+git clone https://github.com/confluentinc/quickstart-streaming-agents.git
+cd quickstart-streaming-agents
+```
+
 Once you have these credentials ready, run the following command and choose **Lab1** (see [main README](./README.md)):
 
   ```bash

--- a/LAB2-Walkthrough.md
+++ b/LAB2-Walkthrough.md
@@ -20,6 +20,13 @@ In this lab, we'll create a Retrieval-Augmented Generation (RAG) pipeline using 
 
 ## Deployment
 
+If you haven't already, clone the repo:
+
+```bash
+git clone https://github.com/confluentinc/quickstart-streaming-agents.git
+cd quickstart-streaming-agents
+```
+
 Use the setup script and select "Lab2" when prompted to automatically deploy Lab2 infrastructure:
 
 ```bash

--- a/LAB3-Walkthrough.md
+++ b/LAB3-Walkthrough.md
@@ -51,7 +51,7 @@ winget install astral-sh.uv Git.Git Hashicorp.Terraform ConfluentInc.Confluent-C
 
 ## Deploy the Demo
 
-First, clone the repo:
+If you haven't already, clone the repo:
 
 ```bash
 git clone https://github.com/confluentinc/quickstart-streaming-agents.git

--- a/LAB4-Walkthrough.md
+++ b/LAB4-Walkthrough.md
@@ -32,7 +32,7 @@ winget install astral-sh.uv Git.Git Hashicorp.Terraform ConfluentInc.Confluent-C
 
 ## Deploy the Demo
 
-First, clone the repo:
+If you haven't already, clone the repo:
 
 ```bash
 git clone https://github.com/confluentinc/quickstart-streaming-agents.git


### PR DESCRIPTION
## Summary
- Lab1 and Lab2 walkthroughs were missing the `git clone` step before the deploy section — a user landing on either lab first had no way to fetch the repo.
- Standardizes the preamble across all four labs to "If you haven't already, clone the repo:" so the wording is consistent regardless of which lab the reader opens first.
- Docs-only change: +16 / −2 across LAB1–LAB4 walkthroughs, no code touched.

## Test plan
- [ ] Read LAB1-Walkthrough.md from the top and confirm the clone block appears before `uv run deploy`.
- [ ] Same check on LAB2-Walkthrough.md.
- [ ] Confirm LAB3 and LAB4 preambles read "If you haven't already, clone the repo:" rather than "First, clone the repo:".

🤖 Generated with [Claude Code](https://claude.com/claude-code)